### PR TITLE
Bring test coverage to 100%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,13 +4,13 @@ coverage:
     status:
         patch:
             default:
-                # target: "100"
+                target: "100"
                 paths:
                   - "tests/"
                   - "src/"
         project:
             default:
-                # target: "100"
+                target: "100"
                 paths:
                   - "tests/"
                   - "src/"

--- a/tests/test_pytz_equivalent.py
+++ b/tests/test_pytz_equivalent.py
@@ -135,7 +135,9 @@ def test_localize_is_dst_none(dt, key):
         except pds.InvalidTimeError as e:
             shim_exc = e
 
-    if (dt_pytz is None) != (dt_shim is None):
+    # This section is triggered rarely. It currently occurs in Python 3 when
+    # key = "Africa/Abidjan" and dt is 1912-01-01.
+    if (dt_pytz is None) != (dt_shim is None):  # pragma: nocover
         uz = pds._compat.get_timezone(key)
 
         utc_off = uz.utcoffset(dt)


### PR DESCRIPTION
This brings the line coverage to 100% and starts enforcing 100% test coverage.

I imagine this could be dicey because of how much of the code is hit via hypothesis, but if any of the coverage metrics ends up flaky, we can just add `hypothesis.example`s to ensure that all the code paths are routinely hit.