### PR TITLE
Add a method to unwrap shim classes

### DIFF
--- a/src/pytz_deprecation_shim/_impl.py
+++ b/src/pytz_deprecation_shim/_impl.py
@@ -82,6 +82,21 @@ class _BasePytzShimTimezone(tzinfo):
             repr(self._key),
         )
 
+    def unwrap_shim(self):
+        """Returns the underlying class that the shim is a wrapper for.
+
+        This is a shim-specific method equivalent to
+        :func:`pytz_deprecation_shim.helpers.upgrade_tzinfo`. It is provided as
+        a method to allow end-users to upgrade shim timezones without requiring
+        an explicit dependency on ``pytz_deprecation_shim``, e.g.:
+
+        .. code-block:: python
+
+            if getattr(tz, "unwrap_shim", None) is None:
+                tz = tz.unwrap_shim()
+        """
+        return self._zone
+
     @property
     def zone(self):
         warnings.warn(

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -17,6 +17,7 @@ from ._common import (
     dt_strategy,
     enfold,
     get_fold,
+    offset_minute_strategy,
     round_normalized,
     valid_zone_strategy,
 )
@@ -214,3 +215,17 @@ def test_folds_from_utc(key, dt_utc, expected_fold):
 
     dt = dt_utc.astimezone(zone)
     assert get_fold(dt) == expected_fold
+
+
+@hypothesis.given(
+    shim_zone=hst.one_of(
+        [
+            valid_zone_strategy.map(pds.timezone),
+            offset_minute_strategy.map(pds.fixed_offset_timezone),
+            hst.just(pds.UTC),
+        ]
+    )
+)
+def test_unwrap_shim(shim_zone):
+    """Tests that .unwrap(_shim) always does the same as upgrade_tzinfo()."""
+    assert shim_zone.unwrap_shim() is pds.helpers.upgrade_tzinfo(shim_zone)


### PR DESCRIPTION
I didn't really want to go beyond the standard `pytz` protocol, but I realized that in order for someone to use `helpers.upgrade_tzinfo`, they would need a direct (not just a transitive) dependency on `pytz_deprecation_shim`, whereas a method on the shim will work even if the library you are calling has stopped returning shims (assuming you call it *only if the method is present*).