### PR TITLE
Add DST inconsistency in CET

### DIFF
--- a/tests/test_pytz_equivalent.py
+++ b/tests/test_pytz_equivalent.py
@@ -291,7 +291,7 @@ def assume_no_dst_inconsistency_bug(dt, key, is_dst=False):  # prama: nocover
         # Possibly another manifestation of dateutil/dateutil#1050
         hypothesis.assume(
             not (
-                key == "MET"
+                (key == "MET" or key == "CET")
                 and datetime(1916, 5, 1) <= dt <= datetime(1916, 10, 2)
             )
         )


### PR DESCRIPTION
It appears that CET and MET are both subject to this bug in Python 2 (at least on Windows).