### PR TITLE
Add support for copy and pickle functions

### DIFF
--- a/src/pytz_deprecation_shim/_impl.py
+++ b/src/pytz_deprecation_shim/_impl.py
@@ -230,6 +230,15 @@ class _PytzShimTimezone(tzinfo):
 
         return dt.astimezone(self)
 
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo=None):
+        return self
+
+    def __reduce__(self):
+        return wrap_zone, (self._zone, self._key)
+
 
 UTC = wrap_zone(_compat.UTC, "UTC")
 PYTZ_MIGRATION_GUIDE_URL = (


### PR DESCRIPTION
Without this `copy.copy` and `copy.deepcopy` (and presumably pickling in general) were broken, as I discovered in broken tests in Django's test suite.