### PR TITLE
Add API reference documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,39 @@
+.. module:: pytz_deprecation_shim
+
+API Reference
+=============
+
+.. data:: UTC
+
+    The UTC singleton (with an alias at ``utc``) is a shim class wrapping
+    either ``datetime.timezone.utc`` or ``dateutil.tz.UTC``.
+
+.. autofunction:: timezone(key)
+
+.. autofunction:: fixed_offset_timezone(offset)
+
+.. autofunction:: build_tzinfo(zone, fp)
+
+.. autofunction:: wrap_zone(tz, key=...)
+
+
+Exceptions
+----------
+
+.. autoexception:: PytzUsageWarning
+
+``pytz`` shim exceptions
+########################
+
+These exceptions are intended to mirror at least some of ``pytz``'s exception
+hierarchy. The shim classes are designed in such a way that the exception
+classes they raise can be caught *either* by catching the value in
+``pytz_deprecation_shim`` or the equivalent exception in ``pytz`` (the actual
+exception type raised will depend on whether or not ``pytz`` has been imported,
+but the value will either be one of the shim exceptions or a subclass of both
+the shim exception and its ``pytz`` equivalent).
+
+.. autoexception:: InvalidTimeError
+.. autoexception:: AmbiguousTimeError
+.. autoexception:: NonExistentTimeError
+.. autoexception:: UnknownTimeZoneError

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,7 @@
    :maxdepth: 2
 
    migration
+   api
    helpers
 
 

--- a/src/pytz_deprecation_shim/_exceptions.py
+++ b/src/pytz_deprecation_shim/_exceptions.py
@@ -2,23 +2,29 @@ from ._common import pytz_imported
 
 
 class PytzUsageWarning(RuntimeWarning):
-    pass
+    """Warning raised when accessing features specific to ``pytz``'s interface.
+
+    This warning is used to direct users of ``pytz``-specific features like the
+    ``localize`` and ``normalize`` methods towards using the standard
+    ``tzinfo`` interface, so that these shims can be replaced with one of the
+    underlying libraries they are wrapping.
+    """
 
 
 class UnknownTimeZoneError(KeyError):
-    pass
+    """Raised when no time zone is found for a specified key."""
 
 
 class InvalidTimeError(Exception):
-    pass
+    """The base class for exceptions related to folds and gaps."""
 
 
 class AmbiguousTimeError(InvalidTimeError):
-    pass
+    """Exception raised when ``is_dst=None`` for an ambiguous time (fold)."""
 
 
 class NonExistentTimeError(InvalidTimeError):
-    pass
+    """Exception raised when ``is_dst=None`` for a non-existent time (gap)."""
 
 
 PYTZ_BASE_ERROR_MAPPING = {}

--- a/src/pytz_deprecation_shim/_impl.py
+++ b/src/pytz_deprecation_shim/_impl.py
@@ -16,6 +16,20 @@ KEY_SENTINEL = object()
 
 
 def timezone(key, _cache={}):
+    """Builds an IANA database time zone shim.
+
+    This is the equivalent of ``pytz.timezone``.
+
+    :param key:
+        A valid key from the IANA time zone database.
+
+    :raises UnknownTimeZoneError:
+        If an unknown value is passed, this will raise an exception that can be
+        caught by :exc:`pytz_deprecation_shim.UnknownTimeZoneError` or
+        ``pytz.UnknownTimeZoneError``. Like
+        :exc:`zoneinfo.ZoneInfoNotFoundError`, both of those are subclasses of
+        :exc:`KeyError`.
+    """
     instance = _cache.get(key, None)
     if instance is None:
         if len(key) == 3 and key.lower() == "utc":
@@ -31,6 +45,21 @@ def timezone(key, _cache={}):
 
 
 def fixed_offset_timezone(offset, _cache={}):
+    """Builds a fixed offset time zone shim.
+
+    This is the equivalent of ``pytz.FixedOffset``. An alias is available as
+    ``pytz_deprecation_shim.FixedOffset`` as well.
+
+    :param offset:
+        A fixed offset from UTC, in minutes. This must be in the range ``-1439
+        <= offset <= 1439``.
+
+    :raises ValueError:
+        For offsets whose absolute value is greater than or equal to 24 hours.
+
+    :return:
+        A shim time zone.
+    """
     if not (-1440 < offset < 1440):
         raise ValueError("absolute offset is too large", offset)
 
@@ -46,7 +75,25 @@ def fixed_offset_timezone(offset, _cache={}):
 
 
 def build_tzinfo(zone, fp):
-    """A shim for pytz.build_tzinfo."""
+    """Builds a shim object from a TZif file.
+
+    This is a shim for ``pytz.build_tzinfo``. Given a value to use as the zone
+    IANA key and a file-like object containing a valid TZif file (i.e.
+    conforming to :rfc:`8536`), this builds a time zone object and wraps it in
+    a shim class.
+
+    The argument names are chosen to match those in ``pytz.build_tzinfo``.
+
+    :param zone:
+        A string to be used as the time zone object's IANA key.
+
+    :param fp:
+        A readable file-like object emitting bytes, pointing to a valid TZif
+        file.
+
+    :return:
+        A shim time zone.
+    """
     zone_file = _compat.get_timezone_file(fp)
 
     return wrap_zone(zone_file, key=zone)
@@ -61,7 +108,7 @@ def wrap_zone(tz, key=KEY_SENTINEL, _cache={}):
     to libraries expecting to use ``pytz``'s interface.
 
     :param tz:
-        A :pep:495-compatible time zone, such as those provided by
+        A :pep:`495`-compatible time zone, such as those provided by
         :mod:`dateutil.tz` or :mod:`zoneinfo`.
 
     :param key:


### PR DESCRIPTION
This does not include documentation of the API of the shim classes, because the shim base class is not a public class, and exposing the documentation without documenting the base class by name might take a bit of work.

It might be that the best option for that is to use a Protocol and document that.