### PR TITLE
Fix str() behavior when key is None

### DIFF
--- a/src/pytz_deprecation_shim/_impl.py
+++ b/src/pytz_deprecation_shim/_impl.py
@@ -162,7 +162,10 @@ class _PytzShimTimezone(tzinfo):
         return dt_out.replace(tzinfo=self)
 
     def __str__(self):
-        return str(self._key)
+        if self._key is not None:
+            return str(self._key)
+        else:
+            return repr(self)
 
     def __repr__(self):
         return "%s(%s, %s)" % (

--- a/tests/test_shims.py
+++ b/tests/test_shims.py
@@ -63,6 +63,12 @@ def test_timezone_utc_singleton(key):
     assert pds.timezone(key) is pds.UTC
 
 
+@hypothesis.given(minutes=offset_minute_strategy.filter(lambda m: m != 0))
+def test_str_fixed_offset(minutes):
+    shim_zone = pds.fixed_offset_timezone(minutes)
+    assert str(shim_zone) == repr(shim_zone)
+
+
 @hypothesis.given(key=valid_zone_strategy)
 def test_timezone_repr(key):
     zone = pds.timezone(key)


### PR DESCRIPTION
This is more consistent with both pytz and zoneinfo.

Closes #19.